### PR TITLE
Update manifest.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,9 +1,10 @@
 applications:
-  - name: s3-broker
-    memory: 256M
-    disk_quota: 256M
-    buildpack: https://github.com/cloudfoundry/go-buildpack.git#v1.7.7
-    env:
-      AWS_ACCESS_KEY_ID: "your-aws-access-key-id"
-      AWS_SECRET_ACCESS_KEY: "your-aws-secret-access-key"
-      GO15VENDOREXPERIMENT: 0
+- name: s3-broker
+  memory: 256M
+  disk_quota: 256M
+  buildpack: go_buildpack
+  command: s3-broker --config ./config.json --port $PORT
+env:
+  GOVERSION: go1.7
+  AWS_ACCESS_KEY_ID: "your-aws-access-key-id"
+  AWS_SECRET_ACCESS_KEY: "your-aws-secret-access-key"


### PR DESCRIPTION
* Pass config and port to start command
* Use default go buildpack instead of pinning specific version
* Unindent environment variables for use with cf-resource
* Use latest known working go version