### PR TITLE
Configure IAM policy.

### DIFF
--- a/awsiam/iam_user_test.go
+++ b/awsiam/iam_user_test.go
@@ -436,8 +436,7 @@ var _ = Describe("IAM User", func() {
 	var _ = Describe("CreatePolicy", func() {
 		var (
 			policyName string
-			effect     string
-			action     string
+			template   string
 			resource   string
 
 			createPolicy *iam.Policy
@@ -448,8 +447,17 @@ var _ = Describe("IAM User", func() {
 
 		BeforeEach(func() {
 			policyName = "policy-name"
-			effect = "effect"
-			action = "action"
+			template = `{
+	"Version": "2012-10-17",
+	"Id": "policy-name",
+	"Statement": [
+		{
+			"Effect": "effect",
+			"Action": "action",
+			"Resource": "{{.Resource}}"
+		}
+	]
+}`
 			resource = "resource"
 
 			createPolicy = &iam.Policy{
@@ -457,9 +465,19 @@ var _ = Describe("IAM User", func() {
 			}
 
 			createPolicyInput = &iam.CreatePolicyInput{
-				Path:           aws.String(iamPath),
-				PolicyName:     aws.String(policyName),
-				PolicyDocument: aws.String("{\"Version\":\"2012-10-17\",\"Id\":\"" + policyName + "\",\"Statement\":[{\"Sid\":\"1\",\"Effect\":\"" + effect + "\",\"Action\":\"" + action + "\",\"Resource\":\"" + resource + "\"},{\"Sid\":\"2\",\"Effect\":\"" + effect + "\",\"Action\":\"" + action + "\",\"Resource\":\"" + resource + "/*\"}]}"),
+				Path:       aws.String(iamPath),
+				PolicyName: aws.String(policyName),
+				PolicyDocument: aws.String(`{
+	"Version": "2012-10-17",
+	"Id": "policy-name",
+	"Statement": [
+		{
+			"Effect": "effect",
+			"Action": "action",
+			"Resource": "resource"
+		}
+	]
+}`),
 			}
 			createPolicyError = nil
 		})
@@ -479,7 +497,7 @@ var _ = Describe("IAM User", func() {
 		})
 
 		It("creates the Access Key", func() {
-			policyARN, err := user.CreatePolicy(policyName, iamPath, effect, action, resource)
+			policyARN, err := user.CreatePolicy(policyName, iamPath, template, resource)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(policyARN).To(Equal("policy-arn"))
 		})
@@ -490,7 +508,7 @@ var _ = Describe("IAM User", func() {
 			})
 
 			It("returns the proper error", func() {
-				_, err := user.CreatePolicy(policyName, iamPath, effect, action, resource)
+				_, err := user.CreatePolicy(policyName, iamPath, template, resource)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("operation failed"))
 			})
@@ -501,7 +519,7 @@ var _ = Describe("IAM User", func() {
 				})
 
 				It("returns the proper error", func() {
-					_, err := user.CreatePolicy(policyName, iamPath, effect, action, resource)
+					_, err := user.CreatePolicy(policyName, iamPath, template, resource)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(Equal("code: message"))
 				})

--- a/awsiam/user.go
+++ b/awsiam/user.go
@@ -11,7 +11,7 @@ type User interface {
 	ListAccessKeys(userName string) ([]string, error)
 	CreateAccessKey(userName string) (string, string, error)
 	DeleteAccessKey(userName, accessKeyID string) error
-	CreatePolicy(policyName, iamPath, effect, action, resource string) (string, error)
+	CreatePolicy(policyName, iamPath, policyTemplate, resource string) (string, error)
 	DeletePolicy(policyARN string) error
 	ListAttachedUserPolicies(userName, iamPath string) ([]string, error)
 	AttachUserPolicy(userName, policyARN string) error

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -171,6 +171,11 @@ func (b *S3Broker) Bind(instanceID, bindingID string, details brokerapi.BindDeta
 	var policyARN string
 	var err error
 
+	servicePlan, ok := b.catalog.FindServicePlan(details.PlanID)
+	if !ok {
+		return binding, fmt.Errorf("Service Plan '%s' not found", details.PlanID)
+	}
+
 	bucketDetails, err := b.bucket.Describe(b.bucketName(instanceID), b.awsPartition)
 	if err != nil {
 		if err == awss3.ErrBucketDoesNotExist {
@@ -199,7 +204,7 @@ func (b *S3Broker) Bind(instanceID, bindingID string, details brokerapi.BindDeta
 		return binding, err
 	}
 
-	policyARN, err = b.user.CreatePolicy(b.policyName(bindingID), b.iamPath, "Allow", "s3:*", bucketDetails.ARN)
+	policyARN, err = b.user.CreatePolicy(b.policyName(bindingID), b.iamPath, string(servicePlan.S3Properties.IamPolicy), bucketDetails.ARN)
 	if err != nil {
 		return binding, err
 	}
@@ -280,7 +285,7 @@ func (b *S3Broker) policyName(bindingID string) string {
 func (b *S3Broker) createBucket(instanceID string, servicePlan ServicePlan, provisionParameters ProvisionParameters, details brokerapi.ProvisionDetails) *awss3.BucketDetails {
 	bucketDetails := b.bucketFromPlan(servicePlan)
 	bucketDetails.Tags = b.bucketTags("Created", details.ServiceID, details.PlanID, details.OrganizationGUID, details.SpaceGUID)
-	bucketDetails.Policy = string(servicePlan.S3Properties.Policy)
+	bucketDetails.Policy = string(servicePlan.S3Properties.BucketPolicy)
 	bucketDetails.AwsPartition = b.awsPartition
 	return bucketDetails
 }

--- a/broker/catalog.go
+++ b/broker/catalog.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/pivotal-cf/brokerapi"
@@ -34,7 +35,8 @@ type ServicePlan struct {
 }
 
 type S3Properties struct {
-	Policy json.RawMessage `json:"policy,omitempty"`
+	IamPolicy    json.RawMessage `json:"iam_policy,omitempty"`
+	BucketPolicy json.RawMessage `json:"bucket_policy,omitempty"`
 }
 
 func (c Catalog) Validate() error {
@@ -112,5 +114,9 @@ func (sp ServicePlan) Validate() error {
 }
 
 func (eq S3Properties) Validate() error {
+	if len(eq.IamPolicy) == 0 {
+		return errors.New("Must provide a non-empty IAM Policy")
+	}
+
 	return nil
 }

--- a/config-sample.json
+++ b/config-sample.json
@@ -49,7 +49,53 @@
               },
               "free": false,
               "s3_properties": {
-
+                "iam_policy": {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Action": [
+                        "s3:DeleteBucketWebsite",
+                        "s3:GetBucketCORS",
+                        "s3:GetBucketLocation",
+                        "s3:GetBucketLogging",
+                        "s3:GetBucketNotification",
+                        "s3:GetBucketTagging",
+                        "s3:GetBucketVersioning",
+                        "s3:GetBucketWebsite",
+                        "s3:ListBucket",
+                        "s3:ListBucketMultipartUploads",
+                        "s3:ListBucketVersions",
+                        "s3:PutBucketCORS",
+                        "s3:PutBucketLogging",
+                        "s3:PutBucketNotification",
+                        "s3:PutBucketVersioning",
+                        "s3:PutBucketWebsite"
+                      ],
+                      "Effect": "Allow",
+                      "Resource": "{{.Resource}}"
+                    },
+                    {
+                      "Action": [
+                        "s3:AbortMultipartUpload",
+                        "s3:DeleteObject",
+                        "s3:DeleteObjectVersion",
+                        "s3:GetObject",
+                        "s3:GetObjectAcl",
+                        "s3:GetObjectTorrent",
+                        "s3:GetObjectVersion",
+                        "s3:GetObjectVersionAcl",
+                        "s3:GetObjectVersionTorrent",
+                        "s3:ListMultipartUploadParts",
+                        "s3:PutObject",
+                        "s3:PutObjectAcl",
+                        "s3:PutObjectVersionAcl",
+                        "s3:RestoreObject"
+                      ],
+                      "Effect": "Allow",
+                      "Resource": "{{.Resource}}/*"
+                    }
+                  ]
+                }
               }
             },
             {
@@ -72,7 +118,54 @@
               },
               "free": false,
               "s3_properties": {
-                "policy": {
+                "iam_policy": {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Action": [
+                        "s3:DeleteBucketWebsite",
+                        "s3:GetBucketCORS",
+                        "s3:GetBucketLocation",
+                        "s3:GetBucketLogging",
+                        "s3:GetBucketNotification",
+                        "s3:GetBucketTagging",
+                        "s3:GetBucketVersioning",
+                        "s3:GetBucketWebsite",
+                        "s3:ListBucket",
+                        "s3:ListBucketMultipartUploads",
+                        "s3:ListBucketVersions",
+                        "s3:PutBucketCORS",
+                        "s3:PutBucketLogging",
+                        "s3:PutBucketNotification",
+                        "s3:PutBucketVersioning",
+                        "s3:PutBucketWebsite"
+                      ],
+                      "Effect": "Allow",
+                      "Resource": "{{.Resource}}"
+                    },
+                    {
+                      "Action": [
+                        "s3:AbortMultipartUpload",
+                        "s3:DeleteObject",
+                        "s3:DeleteObjectVersion",
+                        "s3:GetObject",
+                        "s3:GetObjectAcl",
+                        "s3:GetObjectTorrent",
+                        "s3:GetObjectVersion",
+                        "s3:GetObjectVersionAcl",
+                        "s3:GetObjectVersionTorrent",
+                        "s3:ListMultipartUploadParts",
+                        "s3:PutObject",
+                        "s3:PutObjectAcl",
+                        "s3:PutObjectVersionAcl",
+                        "s3:RestoreObject"
+                      ],
+                      "Effect": "Allow",
+                      "Resource": "{{.Resource}}/*"
+                    }
+                  ]
+                },
+                "bucket_policy": {
                   "Version": "2012-10-17",
                   "Statement": [
                     {

--- a/config-sample.json
+++ b/config-sample.json
@@ -55,10 +55,12 @@
                     {
                       "Action": [
                         "s3:DeleteBucketWebsite",
+                        "s3:GetBucketAcl",
                         "s3:GetBucketCORS",
                         "s3:GetBucketLocation",
                         "s3:GetBucketLogging",
                         "s3:GetBucketNotification",
+                        "s3:GetBucketPolicy",
                         "s3:GetBucketTagging",
                         "s3:GetBucketVersioning",
                         "s3:GetBucketWebsite",
@@ -124,10 +126,12 @@
                     {
                       "Action": [
                         "s3:DeleteBucketWebsite",
+                        "s3:GetBucketAcl",
                         "s3:GetBucketCORS",
                         "s3:GetBucketLocation",
                         "s3:GetBucketLogging",
                         "s3:GetBucketNotification",
+                        "s3:GetBucketPolicy",
                         "s3:GetBucketTagging",
                         "s3:GetBucketVersioning",
                         "s3:GetBucketWebsite",


### PR DESCRIPTION
The current IAM policy of `s3:*` probably allows users to do too much, like deleting the bucket. This patch allows IAM policies to be configured per plan. The default policy is taken from https://github.com/cloudfoundry-community/s3-cf-service-broker.

cc @cnelson 