### PR TITLE
Add granular resource prefixes.

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -21,6 +21,8 @@ const acceptsIncompleteLogKey = "acceptsIncomplete"
 
 type S3Broker struct {
 	iamPath                      string
+	userPrefix                   string
+	policyPrefix                 string
 	bucketPrefix                 string
 	awsPartition                 string
 	allowUserProvisionParameters bool
@@ -44,6 +46,8 @@ func New(
 ) *S3Broker {
 	return &S3Broker{
 		iamPath:                      config.IamPath,
+		userPrefix:                   config.UserPrefix,
+		policyPrefix:                 config.PolicyPrefix,
 		bucketPrefix:                 config.BucketPrefix,
 		awsPartition:                 config.AwsPartition,
 		allowUserProvisionParameters: config.AllowUserProvisionParameters,
@@ -276,11 +280,11 @@ func (b *S3Broker) bucketName(instanceID string) string {
 }
 
 func (b *S3Broker) userName(bindingID string) string {
-	return fmt.Sprintf("%s-%s", b.bucketPrefix, bindingID)
+	return fmt.Sprintf("%s-%s", b.userPrefix, bindingID)
 }
 
 func (b *S3Broker) policyName(bindingID string) string {
-	return fmt.Sprintf("%s-%s", b.bucketPrefix, bindingID)
+	return fmt.Sprintf("%s-%s", b.policyPrefix, bindingID)
 }
 
 func (b *S3Broker) createBucket(instanceID string, servicePlan ServicePlan, provisionParameters ProvisionParameters, details brokerapi.ProvisionDetails) *awss3.BucketDetails {

--- a/broker/config.go
+++ b/broker/config.go
@@ -8,6 +8,8 @@ import (
 type Config struct {
 	Region                       string  `json:"region"`
 	IamPath                      string  `json:"iam_path"`
+	UserPrefix                   string  `json:"user_prefix"`
+	PolicyPrefix                 string  `json:"policy_prefix"`
 	BucketPrefix                 string  `json:"bucket_prefix"`
 	AwsPartition                 string  `json:"aws_partition"`
 	AllowUserProvisionParameters bool    `json:"allow_user_provision_parameters"`
@@ -18,6 +20,14 @@ type Config struct {
 func (c Config) Validate() error {
 	if c.Region == "" {
 		return errors.New("Must provide a non-empty Region")
+	}
+
+	if c.UserPrefix == "" {
+		return errors.New("Must provide a non-empty UserPrefix")
+	}
+
+	if c.PolicyPrefix == "" {
+		return errors.New("Must provide a non-empty PolicyPrefix")
 	}
 
 	if c.BucketPrefix == "" {

--- a/broker/config_test.go
+++ b/broker/config_test.go
@@ -13,6 +13,8 @@ var _ = Describe("Config", func() {
 
 		validConfig = Config{
 			Region:       "s3-region",
+			UserPrefix:   "cf",
+			PolicyPrefix: "cf",
 			BucketPrefix: "cf",
 			Catalog: Catalog{
 				[]Service{
@@ -42,6 +44,22 @@ var _ = Describe("Config", func() {
 			err := config.Validate()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty Region"))
+		})
+
+		It("returns error if UserPrefix is not valid", func() {
+			config.UserPrefix = ""
+
+			err := config.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty UserPrefix"))
+		})
+
+		It("returns error if PolicyPrefix is not valid", func() {
+			config.PolicyPrefix = ""
+
+			err := config.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty PolicyPrefix"))
 		})
 
 		It("returns error if BucketPrefix is not valid", func() {

--- a/config-sample.json
+++ b/config-sample.json
@@ -4,6 +4,8 @@
   "password": "password",
   "s3_config": {
     "region": "us-east-1",
+    "user_prefix": "cf",
+    "policy_prefix": "cf",
     "bucket_prefix": "cf",
     "allow_user_provision_parameters": false,
     "allow_user_update_parameters": false,

--- a/config_test.go
+++ b/config_test.go
@@ -19,6 +19,8 @@ var _ = Describe("Config", func() {
 			Password: "broker-password",
 			S3Config: broker.Config{
 				Region:       "s3-region",
+				UserPrefix:   "cf",
+				PolicyPrefix: "cf",
 				BucketPrefix: "cf",
 				AwsPartition: "aws",
 			},


### PR DESCRIPTION
Add separate settings for user, policy, and bucket prefixes. 

@cnelson 