### PR TITLE
Fix LocationConstraint for default us-east-1 region

### DIFF
--- a/awss3/s3_bucket.go
+++ b/awss3/s3_bucket.go
@@ -43,7 +43,12 @@ func (s *S3Bucket) Describe(bucketName, partition string) (BucketDetails, error)
 	}
 	s.logger.Debug("get-bucket-location", lager.Data{"output": getLocationOutput})
 
-	return s.buildBucketDetails(bucketName, *getLocationOutput.LocationConstraint, partition, nil), nil
+	region := getLocationOutput.LocationConstraint
+	if region == nil {
+		region = aws.String("us-east-1")
+	}
+
+	return s.buildBucketDetails(bucketName, *region, partition, nil), nil
 }
 
 func (s *S3Bucket) Create(bucketName string, bucketDetails BucketDetails) (string, error) {


### PR DESCRIPTION
Hi!
By default AWS API returns empty string for `LocationConstraint` in US East (N. Virginia) region.
https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html
I added validation to override LocationConstraint with actual value for us-east-1 region.
/cc @jmcarp