### PR TITLE
Fips endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 out
 pkg
 gobin/*

--- a/awss3/bucket.go
+++ b/awss3/bucket.go
@@ -19,6 +19,7 @@ type BucketDetails struct {
 	Encryption   string
 	AwsPartition string
 	Tags         map[string]string
+	FIPSEndpoint string
 }
 
 var (

--- a/awss3/s3_bucket.go
+++ b/awss3/s3_bucket.go
@@ -189,6 +189,7 @@ func (s3 *S3Bucket) buildBucketDetails(bucketName, region, partition string, att
 		BucketName: bucketName,
 		Region:     region,
 		ARN:        fmt.Sprintf("arn:%s:s3:::%s", partition, bucketName),
+		FIPSEndpoint: fmt.Sprintf("s3-fips.%s.amazonaws.com", region),
 	}
 }
 

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -52,6 +52,7 @@ type Credentials struct {
 	SecretAccessKey   string   `json:"secret_access_key"`
 	Region            string   `json:"region"`
 	Bucket            string   `json:"bucket"`
+	FIPSEndpoint      string   `json:"fips_endpoint"`
 	AdditionalBuckets []string `json:"additional_buckets"`
 }
 
@@ -312,6 +313,7 @@ func (b *S3Broker) Bind(
 			if bucketDetails.BucketName == b.bucketName(instanceID) {
 				credentials.Bucket = bucketDetails.BucketName
 				credentials.Region = bucketDetails.Region
+				credentials.FIPSEndpoint = bucketDetails.FIPSEndpoint
 			} else {
 				credentials.AdditionalBuckets = append(credentials.AdditionalBuckets, bucketDetails.BucketName)
 			}


### PR DESCRIPTION
This adds the FIPS endpoint information for a bucket to the binding details.
Note that this assumes the FIPS endpoint pattern won't change for regions in the future (in other words, we're generating the endpoint and not asking AWS what it really is)