### PR TITLE
Make S3 service instances shareable between spaces

### DIFF
--- a/config-sample.yml
+++ b/config-sample.yml
@@ -26,6 +26,7 @@ s3_config:
         providerDisplayName: Amazon Web Services
         documentationUrl: https://aws.amazon.com/documentation/s3/
         supportUrl: https://forums.aws.amazon.com/forum.jspa?forumID=24
+        shareable: true
       plan_updateable: false
       plans:
       - id: EAAD05D8-2E01-11E5-9184-FEFF819CDC9F


### PR DESCRIPTION
This enables running `cf share-service SERVICE -s OTHERSPACE` to make a service instance visible and bindable in that other space.

Here's [the spec documentation](https://github.com/openservicebrokerapi/servicebroker/blob/master/profile.md#cloud-foundry-service-metadata).

See [related Slack discussion](https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1637614722002200).